### PR TITLE
Add intersphinx configuration

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -31,7 +31,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.githubpages']
+extensions = ['sphinx.ext.githubpages', 'sphinx.ext.intersphinx']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -197,4 +197,14 @@ epub_copyright = copyright
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
 
+
+# -- Options for intersphinx ----------------------------------------------
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'django': (
+        'http://docs.djangoproject.com/en/stable/',
+        'http://docs.djangoproject.com/en/stable/_objects/'
+    ),
+}
 


### PR DESCRIPTION
Intersphinx is an extension that comes installed with Sphinx that can generate links to the documentation of objects in external projects.
By enabling this extension, an `objects.inv` file will be created when building the documentation. With this file, other projects can easily link to this guide using `ref` and `doc` directives, *e.g*, :ref:`django-views-right-way:starting-point`.
This extension can also be useful to automatically add links to Django modules and classes, *e.g*, `:func:`~django.shortcuts.render` would automatically be converted into a link to the Django docs page for that function.

See: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html